### PR TITLE
Fix ggg-api package name to resolve ts warnings

### DIFF
--- a/src/ggg-api/package.json
+++ b/src/ggg-api/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "echo-common",
+  "name": "ggg-api",
   "version": "1.0.3",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",


### PR DESCRIPTION
ggg-api was labeled as echo-common, resulting in TS errors:
<img width="677" alt="image" src="https://github.com/PoeStack/poestack-sage/assets/4186882/c2c07e24-8e6e-4b3e-96ef-9767f6f89f43">
