### PR TITLE
Add toolchain resolver to fix jvm version error on WSL

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,3 +18,7 @@ include(
 File("src/echo-plugin-examples").listFiles()?.forEach {
   include("src:echo-plugin-examples:${it.name}")
 }
+
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
+}


### PR DESCRIPTION
Running into WSL error when running kotlin tasks. Solution from https://youtrack.jetbrains.com/issue/KTIJ-24981/Gradle-8.-project-sync-fails-with-an-error-No-matching-toolchains-found-for-requested-specification-if-there-is-no-necessary-JDK