### PR TITLE
add ci publishing

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -1,0 +1,43 @@
+name: build/publish
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          cache: "npm"
+          cache-dependency-path: "**/package-lock.json"
+          node-version: "latest"
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "corretto"
+          java-version: "17"
+          cache: "gradle"
+      - name: install
+        run: ./gradlew appBuildNpmInstall
+      - name: build
+        run: ./gradlew appBuildNpmBuild
+
+      - name: Build/release Electron app
+        uses: samuelmeuli/action-electron-builder@v1
+        with:
+          # GitHub token, automatically provided to the action
+          # (No need to define this secret in the repo settings)
+          github_token: ${{ secrets.github_token }}
+          package_root: "./src/echo-app"
+
+          # If the commit is tagged with a version (e.g. "v1.0.0"),
+          # release the app after building
+          release: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,33 @@ buildscript {
   }
 }
 
+val excludedAppBuildProjects = listOf(
+  "src",
+  "echo-plugin-examples",
+  "ggg-test-env",
+  "insights",
+  "insights-cache-updater",
+  "sage-aws-cdk",
+  "sage-docs",
+  "sage-ts-tooling",
+  "tactics-api",
+  "tactics-image-gen"
+)
+
+val appBuildNpmInstall = task("appBuildNpmInstall")
+gradle.projectsEvaluated {
+  subprojects.filter {
+    !excludedAppBuildProjects.contains(it.name)
+  }.forEach { appBuildNpmInstall.dependsOn(it.tasks.named("npmInstall")) }
+}
+
+val appBuildNpmBuild = task("appBuildNpmBuild")
+gradle.projectsEvaluated {
+  subprojects.filter {
+    !excludedAppBuildProjects.contains(it.name)
+  }.forEach { appBuildNpmBuild.dependsOn(it.tasks.named("npmBuild")) }
+}
+
 val buildPlugins = task("buildPlugins")
 gradle.projectsEvaluated {
   subprojects.filter {

--- a/src/echo-app/electron-builder.yml
+++ b/src/echo-app/electron-builder.yml
@@ -44,6 +44,3 @@ linux:
 appImage:
   artifactName: ${name}-${version}.${ext}
 npmRebuild: false
-publish:
-  provider: generic
-  url: https://example.com/auto-updates


### PR DESCRIPTION
Publishes windows and linux builds when you push a new tag. Does not include code signing (which is required to even build Mac), so will add that target when we get our certs ready