### PR TITLE
Fix plugin deploy; load plugins from zip file

### DIFF
--- a/src/echo-app/electron.vite.config.ts
+++ b/src/echo-app/electron.vite.config.ts
@@ -25,7 +25,8 @@ const commonjsPackages = Array.from(
       'axios', // Adapter { https } does only work in node env
       'sqlite3',
       'tail',
-      'i18next-fs-backend'
+      'i18next-fs-backend',
+      'node-stream-zip'
     ],
     ...[
       // Do not include them or the dev serves does not work anymore

--- a/src/echo-app/package-lock.json
+++ b/src/echo-app/package-lock.json
@@ -51,6 +51,7 @@
         "jsonwebtoken": "^9.0.2",
         "libsql": "^0.2.0-pre.2",
         "lucide-react": "^0.292.0",
+        "node-stream-zip": "^1.15.0",
         "object-hash": "^3.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -158,6 +159,7 @@
         "i18next-fs-backend": "^2.3.0",
         "i18next-resources-to-backend": "^1.2.0",
         "lucide-react": "^0.292.0",
+        "node-stream-zip": "^1.15.0",
         "object-hash": "^3.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -11336,6 +11338,18 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "dev": true
+    },
+    "node_modules/node-stream-zip": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.15.0.tgz",
+      "integrity": "sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw==",
+      "engines": {
+        "node": ">=0.12.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/antelle"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/src/echo-app/package.json
+++ b/src/echo-app/package.json
@@ -67,6 +67,7 @@
     "jsonwebtoken": "^9.0.2",
     "libsql": "^0.2.0-pre.2",
     "lucide-react": "^0.292.0",
+    "node-stream-zip": "^1.15.0",
     "object-hash": "^3.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/echo-app/src/renderer/src/locales/en/common.json
+++ b/src/echo-app/src/renderer/src/locales/en/common.json
@@ -18,9 +18,12 @@
     "enterToken": "Enter your PoeStack token. ",
     "tokenPlaceholder": "Token",
     "pluginName": "Plugin Name",
-    "version": "Version",
-    "enabled": "Enabled",
-    "noPluginsInstalled": "No Plugins installed"
+    "pluginVersion": "Version",
+    "pluginEnabled": "Enabled",
+    "pluginStatus": "Status",
+    "installPlugin": "Install",
+    "uninstallPlugin": "Uninstall",
+    "noPluginsAvailable": "No Plugins available"
   },
   "body": {
     "default": ""

--- a/src/echo-app/src/renderer/src/pages/plugin-settings-page.tsx
+++ b/src/echo-app/src/renderer/src/pages/plugin-settings-page.tsx
@@ -1,6 +1,6 @@
 import { bind } from '@react-rxjs/core'
 import { APP_CONTEXT } from '../echo-context-factory'
-import { Input, Table } from 'echo-common/components-v1'
+import { Button, Checkbox, Table } from 'echo-common/components-v1'
 import { useTranslation } from 'react-i18next'
 
 const [usePlugins] = bind(APP_CONTEXT.plugins.currentPlugins$, {})
@@ -11,52 +11,67 @@ export const PluginSettingsPage = () => {
   const plugins = Object.values(pluginMap)
 
   return (
-    <>
-      <div className="p-4 w-full h-full overflow-y-scroll">
-        <div className="flex flex-row">
-          <div className="flex flex-col">
-            <h1 className="font-semibold text-accent-foreground">{t('title.pluginsTableTitle')}</h1>
-          </div>
+    <div className="p-4 w-full h-full overflow-y-scroll">
+      <div className="flex flex-row">
+        <div className="flex flex-col">
+          <h1 className="font-semibold text-accent-foreground">{t('title.pluginsTableTitle')}</h1>
         </div>
-        <Table>
-          <Table.Header>
-            <Table.Row>
-              <Table.Head>{t('label.pluginName')}</Table.Head>
-              <Table.Head>{t('label.version')}</Table.Head>
-              <Table.Head>{t('label.enabled')}</Table.Head>
-            </Table.Row>
-          </Table.Header>
-          <Table.Body>
-            {(plugins || []).length > 0 &&
-              plugins.map((plugin) => (
-                <Table.Row key={plugin.key}>
-                  <Table.Cell>{plugin.manifest?.name}</Table.Cell>
-                  <Table.Cell>{plugin.manifest?.version}</Table.Cell>
-                  {!plugin.path && (
-                    <Table.Cell onClick={() => APP_CONTEXT.plugins.installPlugin(plugin)}>
-                      Install
-                    </Table.Cell>
-                  )}
-                  <Table.Cell className="text-center">
-                    <Input
-                      type="checkbox"
-                      id={`${plugin.manifest?.name}-enabled`}
-                      name="enabled"
-                      checked={!!plugin.enabled}
-                      onChange={() => APP_CONTEXT.plugins.togglePlugin(plugin)}
-                    />
-                  </Table.Cell>
-                </Table.Row>
-              ))}
-            {(plugins || []).length === 0 && (
-              <Table.Row>
-                <Table.Cell colSpan={3}>{t('label.noPluginsInstalled')}</Table.Cell>
-              </Table.Row>
-            )}
-          </Table.Body>
-        </Table>
-        <div className="basis-1/4"></div>
       </div>
-    </>
+      <Table>
+        <Table.Header>
+          <Table.Row>
+            <Table.Head>{t('label.pluginName')}</Table.Head>
+            <Table.Head>{t('label.pluginVersion')}</Table.Head>
+            <Table.Head>{t('label.pluginStatus')}</Table.Head>
+            <Table.Head>{t('label.pluginEnabled')}</Table.Head>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {(plugins || []).length > 0 &&
+            plugins.map((plugin) => (
+              <Table.Row key={plugin.key}>
+                <Table.Cell>{plugin.manifest?.name}</Table.Cell>
+                <Table.Cell>{plugin.manifest?.version}</Table.Cell>
+                <Table.Cell>
+                  {plugin.path && (
+                    <Button
+                      variant="outline"
+                      onClick={() => APP_CONTEXT.plugins.uninstallPlugin(plugin)}
+                    >
+                      {t('label.uninstallPlugin')}
+                    </Button>
+                  )}
+                  {!plugin.path && (
+                    <Button
+                      variant="outline"
+                      onClick={() => APP_CONTEXT.plugins.installPlugin(plugin)}
+                    >
+                      {t('label.installPlugin')}
+                    </Button>
+                  )}
+                </Table.Cell>
+                <Table.Cell>
+                  {plugin.path && (
+                    <div className="flex flex-row items-center justify-start">
+                      <Checkbox
+                        id={`${plugin.manifest?.name}-enabled`}
+                        name="enabled"
+                        checked={!!plugin.enabled}
+                        onCheckedChange={() => APP_CONTEXT.plugins.togglePlugin(plugin)}
+                      />
+                    </div>
+                  )}
+                </Table.Cell>
+              </Table.Row>
+            ))}
+          {(plugins || []).length === 0 && (
+            <Table.Row>
+              <Table.Cell colSpan={3}>{t('label.noPluginsAvailable')}</Table.Cell>
+            </Table.Row>
+          )}
+        </Table.Body>
+      </Table>
+      <div className="basis-1/4"></div>
+    </div>
   )
 }

--- a/src/echo-common/package-lock.json
+++ b/src/echo-common/package-lock.json
@@ -58,6 +58,7 @@
         "i18next-fs-backend": "^2.3.0",
         "i18next-resources-to-backend": "^1.2.0",
         "lucide-react": "^0.292.0",
+        "node-stream-zip": "^1.15.0",
         "object-hash": "^3.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -6856,6 +6857,19 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
       "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
       "dev": true
+    },
+    "node_modules/node-stream-zip": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.15.0.tgz",
+      "integrity": "sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.12.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/antelle"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/src/echo-common/package.json
+++ b/src/echo-common/package.json
@@ -91,6 +91,7 @@
     "i18next-fs-backend": "^2.3.0",
     "i18next-resources-to-backend": "^1.2.0",
     "lucide-react": "^0.292.0",
+    "node-stream-zip": "^1.15.0",
     "object-hash": "^3.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/echo-common/src/echo-plugin-service.ts
+++ b/src/echo-common/src/echo-plugin-service.ts
@@ -6,6 +6,7 @@ import path from 'path'
 import { EchoDirService } from './echo-dir-service'
 import { EchoContext } from './echo-context'
 import { ECHO_CONTEXT_SERVICE } from './echo-context-service'
+import StreamZip from 'node-stream-zip'
 
 export type EchoPluginManifest = { name: string; version: string; echoCommonVersion: string }
 
@@ -44,7 +45,7 @@ export class EchoPluginService {
           const context = buildContext('plugin')
           ECHO_CONTEXT_SERVICE.contexts['plugin'] = context
 
-          const pluginEntry = module.require(p.path)
+          const pluginEntry = module.require(path.resolve(p.path, 'entry.js'))
           const hook: EchoPluginHook = pluginEntry.default()
           hook.start()
           this.plugins$.next({ key: p.key, hook: hook })
@@ -77,25 +78,49 @@ export class EchoPluginService {
     this.plugins$.next({ key: plugin.key, enabled: !plugin.enabled })
   }
 
-  public installPlugin(plugin: EchoPlugin) {
+  private async handlePluginResponse(plugin: EchoPlugin, resp: string) {
+    const pluginPath = path.resolve(this.installedPluginsPath, `${plugin.key}`)
+    if (!fs.existsSync(pluginPath)) {
+      const zipFilePath = path.resolve(pluginPath, `${plugin.key}.zip`)
+
+      fs.mkdirSync(pluginPath)
+      fs.writeFileSync(zipFilePath, resp)
+      const pluginZip = new StreamZip.async({
+        file: zipFilePath
+      })
+      await pluginZip.extract(null, pluginPath)
+      await pluginZip.close()
+      fs.unlinkSync(zipFilePath)
+    }
+  }
+
+  public async installPlugin(plugin: EchoPlugin) {
     return this.httpUtil
       .get<string>(
         `https://raw.githubusercontent.com/PoeStack/poestack-sage/published-plugins/dist_plugins/${
           plugin.manifest!!.name
-        }.js`
+        }.zip`,
+        { responseType: 'arraybuffer' }
       )
-      .subscribe((resp) => {
-        fs.writeFileSync(path.resolve(this.installedPluginsPath, `${plugin.key}.js`), resp)
+      .subscribe(async (resp) => {
+        this.handlePluginResponse(plugin, resp)
         this.loadInstalledPlugins()
       })
+  }
+
+  public uninstallPlugin(plugin: EchoPlugin) {
+    fs.rmdirSync(path.resolve(this.installedPluginsPath, `${plugin.key}`), {
+      recursive: true
+    })
+    this.plugins$.next({ key: plugin.key, path: undefined, enabled: undefined })
+    this.loadInstalledPlugins()
   }
 
   public loadInstalledPlugins() {
     fs.readdir(this.installedPluginsPath, (_, files) => {
       files.forEach((file) => {
-        const pluginKey = file.slice(0, -3)
         const pluginPath = path.resolve(this.installedPluginsPath, file)
-        this.plugins$.next({ key: pluginKey, path: pluginPath })
+        this.plugins$.next({ key: file, path: pluginPath })
       })
     })
   }

--- a/src/echo-plugin-examples/character-plugin/package-lock.json
+++ b/src/echo-plugin-examples/character-plugin/package-lock.json
@@ -15,6 +15,7 @@
         "@types/node": "^20.8.7",
         "@types/react": "^18.2.15",
         "@types/react-dom": "^18.2.7",
+        "@types/rollup-plugin-peer-deps-external": "^2.2.4",
         "@typescript-eslint/eslint-plugin": "^6.9.1",
         "@typescript-eslint/parser": "^6.9.1",
         "eslint": "^8.53.0",
@@ -182,6 +183,7 @@
         "i18next-fs-backend": "^2.3.0",
         "i18next-resources-to-backend": "^1.2.0",
         "lucide-react": "^0.292.0",
+        "node-stream-zip": "^1.15.0",
         "object-hash": "^3.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -1272,6 +1274,35 @@
       "dev": true,
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/rollup-plugin-peer-deps-external": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@types/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.2.4.tgz",
+      "integrity": "sha512-UbIYkFpYjWruIOyzOoatwtzjs/gbyT+2ndBmuKExNSncbJChYLDWxjUsrgaOGo2EyGB3u2/b8V/8wmQ1dgcGrQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "rollup": "^0.63.4"
+      }
+    },
+    "node_modules/@types/rollup-plugin-peer-deps-external/node_modules/@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "node_modules/@types/rollup-plugin-peer-deps-external/node_modules/rollup": {
+      "version": "0.63.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.63.5.tgz",
+      "integrity": "sha512-dFf8LpUNzIj3oE0vCvobX6rqOzHzLBoblyFp+3znPbjiSmSvOoK2kMKx+Fv9jYduG1rvcCfCveSgEaQHjWRF6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "0.0.39",
+        "@types/node": "*"
+      },
+      "bin": {
+        "rollup": "bin/rollup"
       }
     },
     "node_modules/@types/semver": {

--- a/src/echo-plugin-examples/character-plugin/package.json
+++ b/src/echo-plugin-examples/character-plugin/package.json
@@ -43,6 +43,7 @@
     "@types/node": "^20.8.7",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
+    "@types/rollup-plugin-peer-deps-external": "^2.2.4",
     "@typescript-eslint/eslint-plugin": "^6.9.1",
     "@typescript-eslint/parser": "^6.9.1",
     "eslint": "^8.53.0",

--- a/src/echo-plugin-examples/character-plugin/rollup.config.ts
+++ b/src/echo-plugin-examples/character-plugin/rollup.config.ts
@@ -1,6 +1,6 @@
 import typescript from '@rollup/plugin-typescript'
 import peerDepsExternal from 'rollup-plugin-peer-deps-external'
-import type { RollupOptions } from 'rollup'
+import type { InputPluginOption, RollupOptions } from 'rollup'
 import fs from 'fs'
 import path from 'path'
 import copy from 'rollup-plugin-copy'
@@ -21,7 +21,7 @@ const config: RollupOptions = {
     plugins: [terser()]
   },
   plugins: [
-    peerDepsExternal(),
+    peerDepsExternal() as InputPluginOption,
     json({ compact: true }),
     typescript(),
     // This converts dynamic imports for locales from ../locales/${lng}/${ns}.json => ../locales/*/*.json => ../locales/en/common.json
@@ -34,7 +34,7 @@ const config: RollupOptions = {
           dest: `../../../dist_plugins/`
         }
       ],
-      hook: 'writeBundle'
+      hook: 'closeBundle'
     })
   ]
 }

--- a/src/echo-plugin-examples/poe-log-plugin/package-lock.json
+++ b/src/echo-plugin-examples/poe-log-plugin/package-lock.json
@@ -15,6 +15,7 @@
         "@types/node": "^20.8.7",
         "@types/react": "^18.2.15",
         "@types/react-dom": "^18.2.7",
+        "@types/rollup-plugin-peer-deps-external": "^2.2.4",
         "@typescript-eslint/eslint-plugin": "^6.9.1",
         "@typescript-eslint/parser": "^6.10.0",
         "eslint": "^8.53.0",
@@ -253,6 +254,7 @@
         "i18next-fs-backend": "^2.3.0",
         "i18next-resources-to-backend": "^1.2.0",
         "lucide-react": "^0.292.0",
+        "node-stream-zip": "^1.15.0",
         "object-hash": "^3.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -1343,6 +1345,35 @@
       "dev": true,
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/rollup-plugin-peer-deps-external": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@types/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.2.4.tgz",
+      "integrity": "sha512-UbIYkFpYjWruIOyzOoatwtzjs/gbyT+2ndBmuKExNSncbJChYLDWxjUsrgaOGo2EyGB3u2/b8V/8wmQ1dgcGrQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "rollup": "^0.63.4"
+      }
+    },
+    "node_modules/@types/rollup-plugin-peer-deps-external/node_modules/@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "node_modules/@types/rollup-plugin-peer-deps-external/node_modules/rollup": {
+      "version": "0.63.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.63.5.tgz",
+      "integrity": "sha512-dFf8LpUNzIj3oE0vCvobX6rqOzHzLBoblyFp+3znPbjiSmSvOoK2kMKx+Fv9jYduG1rvcCfCveSgEaQHjWRF6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "0.0.39",
+        "@types/node": "*"
+      },
+      "bin": {
+        "rollup": "bin/rollup"
       }
     },
     "node_modules/@types/semver": {

--- a/src/echo-plugin-examples/poe-log-plugin/package.json
+++ b/src/echo-plugin-examples/poe-log-plugin/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "example-character-plugin",
+  "name": "example-log-plugin",
   "private": true,
   "version": "0.0.0",
   "type": "commonjs",
@@ -43,6 +43,7 @@
     "@types/node": "^20.8.7",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
+    "@types/rollup-plugin-peer-deps-external": "^2.2.4",
     "@typescript-eslint/eslint-plugin": "^6.9.1",
     "@typescript-eslint/parser": "^6.10.0",
     "eslint": "^8.53.0",

--- a/src/echo-plugin-examples/poe-log-plugin/rollup.config.ts
+++ b/src/echo-plugin-examples/poe-log-plugin/rollup.config.ts
@@ -1,6 +1,6 @@
 import typescript from '@rollup/plugin-typescript'
 import peerDepsExternal from 'rollup-plugin-peer-deps-external'
-import type { RollupOptions } from 'rollup'
+import type { InputPluginOption, RollupOptions } from 'rollup'
 import fs from 'fs'
 import path from 'path'
 import copy from 'rollup-plugin-copy'
@@ -21,7 +21,7 @@ const config: RollupOptions = {
     plugins: [terser()]
   },
   plugins: [
-    peerDepsExternal(),
+    peerDepsExternal() as InputPluginOption,
     json({ compact: true }),
     typescript(),
     // This converts dynamic imports for locales from ../locales/${lng}/${ns}.json => ../locales/*/*.json => ../locales/en/common.json
@@ -34,7 +34,7 @@ const config: RollupOptions = {
           dest: `../../../dist_plugins/`
         }
       ],
-      hook: 'writeBundle'
+      hook: 'closeBundle'
     })
   ]
 }

--- a/src/echo-plugin-examples/stash-plugin/package-lock.json
+++ b/src/echo-plugin-examples/stash-plugin/package-lock.json
@@ -15,6 +15,7 @@
         "@types/node": "^20.8.7",
         "@types/react": "^18.2.15",
         "@types/react-dom": "^18.2.7",
+        "@types/rollup-plugin-peer-deps-external": "^2.2.4",
         "@typescript-eslint/eslint-plugin": "^6.9.1",
         "@typescript-eslint/parser": "^6.10.0",
         "eslint": "^8.53.0",
@@ -182,6 +183,7 @@
         "i18next-fs-backend": "^2.3.0",
         "i18next-resources-to-backend": "^1.2.0",
         "lucide-react": "^0.292.0",
+        "node-stream-zip": "^1.15.0",
         "object-hash": "^3.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -1272,6 +1274,35 @@
       "dev": true,
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/rollup-plugin-peer-deps-external": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@types/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.2.4.tgz",
+      "integrity": "sha512-UbIYkFpYjWruIOyzOoatwtzjs/gbyT+2ndBmuKExNSncbJChYLDWxjUsrgaOGo2EyGB3u2/b8V/8wmQ1dgcGrQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "rollup": "^0.63.4"
+      }
+    },
+    "node_modules/@types/rollup-plugin-peer-deps-external/node_modules/@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "node_modules/@types/rollup-plugin-peer-deps-external/node_modules/rollup": {
+      "version": "0.63.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.63.5.tgz",
+      "integrity": "sha512-dFf8LpUNzIj3oE0vCvobX6rqOzHzLBoblyFp+3znPbjiSmSvOoK2kMKx+Fv9jYduG1rvcCfCveSgEaQHjWRF6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "0.0.39",
+        "@types/node": "*"
+      },
+      "bin": {
+        "rollup": "bin/rollup"
       }
     },
     "node_modules/@types/semver": {

--- a/src/echo-plugin-examples/stash-plugin/package.json
+++ b/src/echo-plugin-examples/stash-plugin/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "example-character-plugin",
+  "name": "example-stash-plugin",
   "private": true,
   "version": "0.0.0",
   "type": "commonjs",
@@ -43,6 +43,7 @@
     "@types/node": "^20.8.7",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
+    "@types/rollup-plugin-peer-deps-external": "^2.2.4",
     "@typescript-eslint/eslint-plugin": "^6.9.1",
     "@typescript-eslint/parser": "^6.10.0",
     "eslint": "^8.53.0",

--- a/src/echo-plugin-examples/stash-plugin/rollup.config.ts
+++ b/src/echo-plugin-examples/stash-plugin/rollup.config.ts
@@ -1,6 +1,6 @@
 import typescript from '@rollup/plugin-typescript'
 import peerDepsExternal from 'rollup-plugin-peer-deps-external'
-import type { RollupOptions } from 'rollup'
+import type { InputPluginOption, RollupOptions } from 'rollup'
 import fs from 'fs'
 import path from 'path'
 import copy from 'rollup-plugin-copy'
@@ -21,7 +21,7 @@ const config: RollupOptions = {
     plugins: [terser()]
   },
   plugins: [
-    peerDepsExternal(),
+    peerDepsExternal() as InputPluginOption,
     json({ compact: true }),
     typescript(),
     // This converts dynamic imports for locales from ../locales/${lng}/${ns}.json => ../locales/*/*.json => ../locales/en/common.json
@@ -34,7 +34,7 @@ const config: RollupOptions = {
           dest: `../../../dist_plugins/`
         }
       ],
-      hook: 'writeBundle'
+      hook: 'closeBundle'
     })
   ]
 }

--- a/src/sage-common/src/utils/http-util.ts
+++ b/src/sage-common/src/utils/http-util.ts
@@ -1,19 +1,14 @@
 import { Observable } from 'rxjs'
-import axios from 'axios'
+import axios, { AxiosRequestConfig } from 'axios'
 
 export class HttpUtil {
   private client = axios.create({ adapter: 'http' })
 
-  public get<T>(
-    url: string,
-    config: { headers: { [key: string]: string } } = { headers: {} }
-  ): Observable<T> {
+  public get<T>(url: string, config: AxiosRequestConfig = { headers: {} }): Observable<T> {
     return new Observable((observer) => {
       console.log('firing', url)
       this.client
-        .get(url, {
-          headers: config.headers
-        })
+        .get(url, config)
         .then((response) => {
           console.log('res', url, response.status)
           observer.next(response.data)


### PR DESCRIPTION
- Pushed zips were corrupt due to wrong hook in rollup config
- Example plugins were clobbering due to incorrect package name
- Add ability to install remote plugin and uninstall
- Add missing types to example plugins
- Extends config options for httpUtil