### PR TITLE
Fix preview command for Windows

### DIFF
--- a/src/echo-app/package-lock.json
+++ b/src/echo-app/package-lock.json
@@ -92,6 +92,7 @@
         "@typescript-eslint/parser": "^6.10.0",
         "@vitejs/plugin-react": "^4.0.4",
         "autoprefixer": "^10.4.16",
+        "cross-env": "^7.0.3",
         "dotenv-cli": "^7.3.0",
         "drizzle-kit": "^0.20.4",
         "electron": "^25.6.0",
@@ -6626,6 +6627,24 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",

--- a/src/echo-app/package.json
+++ b/src/echo-app/package.json
@@ -7,7 +7,7 @@
   "main": "./out/main/index.js",
   "scripts": {
     "build": "npm run bump-dev-plugins && npm run typecheck && electron-vite build",
-    "preview": "IS_PREVIEW=true electron-vite preview",
+    "preview": "cross-env IS_PREVIEW=true electron-vite preview",
     "build:linux": "npm run build && electron-builder --linux --config",
     "build:mac": "npm run build && electron-builder --mac --config",
     "build:plugins": "cd ../../ && gradlew buildPlugins",
@@ -108,6 +108,7 @@
     "@typescript-eslint/parser": "^6.10.0",
     "@vitejs/plugin-react": "^4.0.4",
     "autoprefixer": "^10.4.16",
+    "cross-env": "^7.0.3",
     "dotenv-cli": "^7.3.0",
     "drizzle-kit": "^0.20.4",
     "electron": "^25.6.0",


### PR DESCRIPTION
Windows doesn't set env vars the same as other platforms. Uses cross-env package to allow the preview command to work on all platforms